### PR TITLE
blog: offloading dependency management to Renovate

### DIFF
--- a/content/blog/offloading-dependency-management-to-renovate.md
+++ b/content/blog/offloading-dependency-management-to-renovate.md
@@ -1,0 +1,54 @@
+---
+date: 2026-06-18
+isPublished: true
+slug: offloading-dependency-management-to-renovate
+tags: ["renovate", "automation", "devtools", "ci"]
+title: "Offloading Dependency Management to Renovate"
+---
+
+Six pull requests landed on this site today. Astro, happy-dom, Node.js, pnpm, lucide-react, actions/checkout — each one a version bump. I didn't open a single one. Barely thought about them. Renovate did the work, and a rebase script closed them out in a few minutes.
+
+That's the whole pitch. Spend a little time upfront, save a little time every week, never think about dependency updates again.
+
+## What Renovate does
+
+Renovate watches your dependencies and opens PRs when new versions are available. You configure it once with a schedule, grouping rules, and auto-merge preferences, and it keeps going.
+
+Mine is about as simple as it gets. The `renovate.json` at the root of the repo just extends a shared config:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>AndrewUsher/renovate-config"
+  ]
+}
+```
+
+That shared config sets defaults across all my projects — weekly schedule, grouped monorepo updates, separate PRs for majors. Nothing clever. Renovate does the heavy lifting: it reads your `package.json`, figures out the package manager, and crawls the dependency graph.
+
+## Why it works
+
+Dependency updates are mechanical. A new version of a transitive dependency almost never needs a human to think about it. The question is always the same: does it break the build? Tests pass, types check out, ship it.
+
+Renovate opens the PRs. I scan the diff, check CI, hit merge. That's the whole loop.
+
+Today's batch was typical. Node.js 24.17.0 fixed 11 security vulnerabilities, two of them high-severity. Astro 6.4.8 hardened URL decoding limits. These land in production within days of the release, not whenever I get around to running `npm outdated`.
+
+## The part that matters most
+
+The single biggest win isn't visible in any one PR. It's that dependencies never drift.
+
+When you batch updates once a quarter, every upgrade turns into a project. Breaking changes pile up. Migration guides overlap. A five-minute version bump becomes an afternoon of untangling regressions. I've been there. It's not fun.
+
+Renovate sidesteps the whole thing. Small updates land continuously. When a major version eventually rolls through, the diff is isolated to that one change. No mystery breakage from skipping three minor versions.
+
+## The cost
+
+Setup takes an afternoon: install the app, write your config, tweak the grouping until the PRs look like what you want. Ongoing cost is near zero. I spend maybe 10 minutes a week scanning PRs and clicking merge.
+
+For this site with its 40-odd dependencies, that's an easy trade. For anything bigger, it's not even a question.
+
+## Try it
+
+Install the [Renovate GitHub app](https://github.com/apps/renovate), point it at a repo, and let it open the onboarding PR. The defaults work fine out of the box. You can tune from there.


### PR DESCRIPTION
New post about why I use Renovate for automated dependency updates on this site. Covers the setup, the workflow, and why continuous small updates beat quarterly dependency binges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published a new blog post on automated dependency management using Renovate, covering configuration strategies, workflow best practices, and benefits for maintaining current dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->